### PR TITLE
Interval#complementRelativeTo() のバグ？

### DIFF
--- a/src/main/java/jp/tricreo/baseunits/intervals/Interval.java
+++ b/src/main/java/jp/tricreo/baseunits/intervals/Interval.java
@@ -772,16 +772,15 @@ public class Interval<T extends Comparable<T>> implements Serializable {
 		return other.upperLimit();
 	}
 	
+	/**
+	 * この区間の下側<b>補</b>区間と与えた区間 {@code other} の共通部分を返す。
+	 *
+	 * @param other 比較対象の区間
+	 * @return この区間の下側の補区間と、与えた区間の共通部分。存在しない場合は {@code null}
+	 */
 	private Interval<T> leftComplementRelativeTo(Interval<T> other) {
-		T lesserOfLowerLimits = lesserOfLowerLimits(other);
-		if (lesserOfLowerLimits == null) {
-			// TODO 何してるか分からないままテストを通すためだけにこのif文を作った。熟考せよ。
-			return null;
-		}
-		if (this.includes(lesserOfLowerLimits)) {
-			return null;
-		}
-		if (lowerLimit().equals(other.lowerLimit()) && other.includesLowerLimit() == false) {
+		// この区間の下側限界値の方が小さいか等しい場合、下側の補区間に共通部分は無い
+		if (this.lowerLimitObject.compareTo(other.lowerLimitObject) <= 0) {
 			return null;
 		}
 		return newOfSameType(other.lowerLimit(), other.includesLowerLimit(), this.lowerLimit(),
@@ -815,16 +814,15 @@ public class Interval<T extends Comparable<T>> implements Serializable {
 		return this.includes(limit) || other.includes(limit);
 	}
 	
+	/**
+	 * この区間の上側<b>補</b>区間と与えた区間 {@code other} の共通部分を返す。
+	 *
+	 * @param other 比較対象の区間
+	 * @return この区間の上側の補区間と、与えた区間の共通部分。存在しない場合は {@code null}
+	 */
 	private Interval<T> rightComplementRelativeTo(Interval<T> other) {
-		T greaterOfUpperLimits = greaterOfUpperLimits(other);
-		if (greaterOfUpperLimits == null) {
-			// TODO 何してるか分からないままテストを通すためだけにこのif文を作った。熟考せよ。
-			return null;
-		}
-		if (this.includes(greaterOfUpperLimits)) {
-			return null;
-		}
-		if (upperLimit().equals(other.upperLimit()) && other.includesUpperLimit() == false) {
+		// この区間の上側限界値の方が大きいか等しい場合、上側の補区間に共通部分は無い
+		if (this.upperLimitObject.compareTo(other.upperLimitObject) >= 0) {
 			return null;
 		}
 		return newOfSameType(this.upperLimit(), this.includesUpperLimit() == false, other.upperLimit(),

--- a/src/test/java/jp/tricreo/baseunits/intervals/IntervalTest.java
+++ b/src/test/java/jp/tricreo/baseunits/intervals/IntervalTest.java
@@ -786,4 +786,35 @@ public class IntervalTest {
 		assertThat(empty.toString(), is("{}"));
 		assertThat(Interval.closed(10, 10).toString(), is("{10}"));
 	}
+
+	
+	/**
+	 * {@link Interval#complementRelativeTo(Interval)}のテスト。
+	 *
+	 * @throws Exception 例外が発生した場合
+	 */
+	@Test
+	public void test31_RelativeComplementOverlapRightOpen() throws Exception {
+		Interval<Integer> c3_7o = Interval.over(3, true, 6, false);
+		Interval<Integer> c1_5o = Interval.over(1, true, 5, false);
+		List<Interval<Integer>> complement = c3_7o.complementRelativeTo(c1_5o);
+		Interval<Integer> c1_3o = Interval.over(1, true, 3, false);
+		assertThat(complement.size(), is(1));
+		assertThat(complement.get(0), is(c1_3o));
+	}
+
+	/**
+	 * {@link Interval#complementRelativeTo(Interval)}のテスト。
+	 *
+	 * @throws Exception 例外が発生した場合
+	 */
+	@Test
+	public void test32_RelativeComplementOverlapLeftOpen() throws Exception {
+		Interval<Integer> o1_5c = Interval.over(1, false, 5, true);
+		Interval<Integer> o3_7c = Interval.over(2, false, 7, true);
+		List<Interval<Integer>> complement = o1_5c.complementRelativeTo(o3_7c);
+		Interval<Integer> o5_7c = Interval.over(5, false, 7, true);
+		assertThat(complement.size(), is(1));
+		assertThat(complement.get(0), is(o5_7c));
+	}
 }


### PR DESCRIPTION
Interval#complementRelativeTo() に特定の条件で IllegalArgumentException が発生するバグっぽい挙動があり、修正してみたので一応 pull request します。

例：
Interval<Integer> c3_6o = Interval.over(3, true, 6, false);
Interval<Integer> c1_5o = Interval.over(1, true, 5, false);
c3_6o.complementRelativeTo(c1_5o); // [1, 3) の1要素リストを期待

java.lang.IllegalArgumentException: <lower closed 6> is not before or equal to <upper open 5>
    at jp.tricreo.baseunits.intervals.Interval.checkLowerIsLessThanOrEqualUpper(Interval.java:744)
    at jp.tricreo.baseunits.intervals.Interval.<init>(Interval.java:196)
    at jp.tricreo.baseunits.intervals.Interval.<init>(Interval.java:181)
    at jp.tricreo.baseunits.intervals.Interval.newOfSameType(Interval.java:597)
    at jp.tricreo.baseunits.intervals.Interval.rightComplementRelativeTo(Interval.java:830)
    at jp.tricreo.baseunits.intervals.Interval.complementRelativeTo(Interval.java:238)
（略）

発生条件としては、区間 A, B が
A:  [3, 6)
B:  [1, 5)
や
A:  (1, 5]
B:  (2, 7]
のように、
- Aの上側限界が開区間＋Aの限界の方が大きい
- Aの下側限界が開区間＋Aの限界の方が小さい
  のどちらかの場合に A.complenentRelativeTo(B) を呼び出すと発生するようです。

確認いただければ幸いです。
