### PR TITLE
#2 fix bug of CalendarWeek#plusWeeks first week of years

### DIFF
--- a/src/main/java/jp/xet/baseunits/time/CalendarWeek.java
+++ b/src/main/java/jp/xet/baseunits/time/CalendarWeek.java
@@ -316,9 +316,8 @@ public class CalendarWeek implements Comparable<CalendarWeek>, Serializable {
 	public CalendarWeek plusWeeks(int increment) {
 		Calendar calendar = asJavaCalendarUniversalZoneMidnight();
 		calendar.add(Calendar.WEEK_OF_YEAR, increment);
-		int yearValue = calendar.get(Calendar.YEAR);
-		int weekValue = calendar.get(Calendar.WEEK_OF_YEAR);
-		return CalendarWeek.from(yearValue, weekValue);
+		CalendarDate calendarDate = CalendarDate.from(calendar);
+		return CalendarWeek.from(calendarDate);
 	}
 	
 	/**

--- a/src/test/java/jp/xet/baseunits/time/CalendarWeekTest.java
+++ b/src/test/java/jp/xet/baseunits/time/CalendarWeekTest.java
@@ -183,4 +183,14 @@ public class CalendarWeekTest {
 		assertThat(CalendarWeek.from(2012, 23).isBefore(CalendarWeek.from(2012, 24)), is(true));
 		assertThat(CalendarWeek.from(2012, 23).isBefore(null), is(false));
 	}
+	
+	/**
+	 * {@link CalendarWeek#plusWeeks(int)}のテスト。
+	 * 
+	 * @throws Exception 例外が発生した場合
+	 */
+	@Test
+	public void test11_plusWeeks() throws Exception {
+		assertThat(CalendarWeek.from(2013, 2).plusWeeks(-1), is(CalendarWeek.from(2013, 1)));
+	}
 }


### PR DESCRIPTION
issue に挙げた #2 CarendarWeek plusWeeks で結果が年の第１週目になるようにすると、結果の年が1年ずれる のテスト及び修正です
